### PR TITLE
feat: support underscore-separated numeric literals

### DIFF
--- a/syntax/odin.vim
+++ b/syntax/odin.vim
@@ -53,12 +53,12 @@ syntax region odinAttribute
       \ start="@\ze(" end="\ze)"
       \ transparent oneline
 
-syntax match odinInteger "\-\?\<\d\+\>" display
-syntax match odinFloat "\-\?\<[0-9][0-9_]*\%(\.[0-9][0-9_]*\)\%([eE][+-]\=[0-9_]\+\)\=" display
-syntax match odinHex "\<0[xX][0-9A-Fa-f]\+\>" display
-syntax match odinDoz "\<0[zZ][0-9a-bA-B]\+\>" display
-syntax match odinOct "\<0[oO][0-7]\+\>" display
-syntax match odinBin "\<0[bB][01]\+\>" display
+syntax match odinInteger "\v-?<[0-9]+%(_[0-9]+)*>" display
+syntax match odinFloat "\v-?<[0-9]+%(_[0-9]+)*%(\.[0-9]+%(_[0-9]+)*)%([eE][+-]=[0-9]+%(_[0-9]+)*)=" display
+syntax match odinHex "\v<0[xX][0-9A-Fa-f]+%(_[0-9A-Fa-f]+)*>" display
+syntax match odinDoz "\v<0[zZ][0-9A-Ba-b]+%(_[0-9A-Ba-b]+)*>" display
+syntax match odinOct "\v<0[oO][0-7]+%(_[0-7]+)*>" display
+syntax match odinBin "\v<0[bB][01]+%(_[01]+)*>" display
 
 syntax match odinAddressOf "&" display
 syntax match odinDeref "\^" display


### PR DESCRIPTION
Add support for underscore-separated numeric literals in Odin syntax highlighting. This allows proper highlighting of numbers like `1_000_000`, `0xFF_AA_BB`, and `0b1010_1111` as specified in the Odin language.

> Numerical literals are written similar to most other programming languages. A useful feature in Odin is that underscores are allowed for better readability: `1_000_000_000` (one billion).
> https://odin-lang.org/docs/overview/#numbers